### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2019-06-11
+
+### Added
+
+- You can now pass selector strings or `<link>` elements directly, rather than wrapping it in a config object.
+- When using an Array to specify multiple icons to target, the different options (selector, `HTMLLinkElement`, config object) can be mixed-and-matched
+- In addition to Arrays, `favicon-mode-switcher` now also supports `NodeList` so you can use it with `document.querySelectorAll()`
+
+### Changed
+
+- Update tests and docs to match new options
+
 ## [1.0.4] - 2019-06-02
 
 ### Changed

--- a/favicon-mode-switcher.js
+++ b/favicon-mode-switcher.js
@@ -2,6 +2,7 @@
 
 /** @typedef { import('index').ColorScheme } ColorScheme */
 /** @typedef { import('index').Icon } Icon */
+/** @typedef { import('index').FaviconTarget } FaviconTarget */
 /** @typedef { import('index').default } FaviconModeSwitcher */
 
 const DEBUG = true
@@ -10,18 +11,25 @@ const warn = (/** @type { string } */ msg) => typeof console !== 'undefined' && 
 /** @type { FaviconModeSwitcher } */
 let faviconModeSwitcher = options => {
   let isBrowser = typeof window !== 'undefined'
-  if (!isBrowser || !options || !window.matchMedia) return () => {}
+  if (!isBrowser || !window.matchMedia) return () => {}
 
-  options = Array.isArray(options) ? options : [options]
+  options = (Array.isArray(options) || options instanceof NodeList) ? options : [options]
 
   /** @type { Icon[] } */
   let icons = []
-  options.forEach(opt => {
-    let linkEl = typeof opt.element === 'string' ? document.querySelector(opt.element) : opt.element
-    if (linkEl && linkEl instanceof HTMLLinkElement) {
-      icons.push({ linkElement: linkEl, hrefConfig: opt.href, baseHref: linkEl.href })
+  ;[].forEach.call(options, (/** @type { FaviconTarget } */ target) => {
+    if (typeof target === 'string' || target instanceof HTMLLinkElement) {
+      target = { element: target }
+    }
+
+    // prettier-ignore
+    let linkElement = target && (
+      typeof target.element === 'string' ? document.querySelector(target.element) : target.element
+    )
+    if (linkElement && linkElement instanceof HTMLLinkElement) {
+      icons.push({ linkElement, hrefConfig: target.href, baseHref: linkElement.href })
     } else if (DEBUG) {
-      warn('[favicon-mode-switcher] Icon not found or not an HTMLLinkElement: ' + opt.element)
+      warn('[favicon-mode-switcher] Icon not found or not an HTMLLinkElement: ' + target)
     }
   })
 

--- a/favicon-mode-switcher.js
+++ b/favicon-mode-switcher.js
@@ -26,7 +26,7 @@ let faviconModeSwitcher = options => {
     let linkElement = target && (
       typeof target.element === 'string' ? document.querySelector(target.element) : target.element
     )
-    if (linkElement && linkElement instanceof HTMLLinkElement) {
+    if (linkElement instanceof HTMLLinkElement) {
       icons.push({ linkElement, hrefConfig: target.href, baseHref: linkElement.href })
     } else if (DEBUG) {
       warn('[favicon-mode-switcher] Icon not found or not an HTMLLinkElement: ' + target)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,13 @@
 export as namespace faviconModeSwitcher
 
-/** Supported color schemes. */
 export type ColorScheme = 'dark' | 'light'
+
+/**
+ * *Keep these props in sync with minifier option --mangle-props in `package.json`*
+ */
+export type Icon = { linkElement: HTMLLinkElement; hrefConfig?: HrefConfig; baseHref: string }
+
+export type Selector = Parameters<Document['querySelector']>[0]
 
 export type HrefConfig = { [Key in ColorScheme]?: string }
 
@@ -13,11 +19,10 @@ export type HrefConfig = { [Key in ColorScheme]?: string }
  * HTMLLinkElement will be updated/replaced according to the active color scheme.
  */
 export type IconConfig = {
-  /** CSS selector to get the **`HTMLLinkElement`** whose href should be updated on mode change.
-   *
-   *  Passed to `document.querySelector()`.
+  /** An `HTMLLinkElement` or a CSS selector that must return an `HTMLLinkElement`
+   *  when passed to `document.querySelector()`.
    */
-  element: string | HTMLLinkElement
+  element: Selector | HTMLLinkElement
   /**
    * Specifies the resource URIs to use. If you omit this property, the substring `"light"` or
    * `"dark"` in the original URI found on the HTMLLinkElement will be *updated / replaced*
@@ -31,10 +36,7 @@ export type IconConfig = {
   href?: HrefConfig
 }
 
-/**
- * *Keep these props in sync with minifier option --mangle-props in `package.json`*
- */
-export type Icon = { linkElement: HTMLLinkElement; hrefConfig?: HrefConfig; baseHref: string }
+export type FaviconTarget = Selector | HTMLLinkElement | IconConfig
 
 /** Remove the color scheme listeners and reset all icons to their original href. */
 declare function DestroyFunction(): void
@@ -42,8 +44,10 @@ declare function DestroyFunction(): void
 /**
  * Takes in icon configuration, sets up listeners for the active color scheme
  * and updates hrefs of the specified icons whenever the active scheme changes.
- * @param options The configuration, either an object for one icon or an array of config objects.
+ * @param options A CSS selector, an HTMLLinkElement or a config object. Can also be an an array.
  */
-declare function FaviconModeSwitcher(options: IconConfig | IconConfig[]): typeof DestroyFunction
+declare function FaviconModeSwitcher(
+  options: FaviconTarget | FaviconTarget[] | NodeListOf<HTMLLinkElement>,
+): typeof DestroyFunction
 
 export default FaviconModeSwitcher

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "favicon-mode-switcher",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "🕯 Make your favicon adapt to dark and light mode",
   "main": "dist/index.min.js",
   "unpkg": "dist/index.umd.min.js",

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,96 @@
+/** @typedef { import('index').ColorScheme } ColorScheme */
+/** @typedef { Parameters<MediaQueryList['addListener']>[0] } QueryListener */
+
+/** @type { HTMLElement[] } */
+let insertedElements = []
+
+/** @template { keyof HTMLElementTagNameMap } TagName */
+/** @param { TagName } tagName */
+/** @param { Partial<HTMLElementTagNameMap[TagName]> } props */
+/** @returns { HTMLElementTagNameMap[TagName] } */
+export const createElement = (tagName, props = {}) => {
+  const element = document.body.appendChild(Object.assign(document.createElement(tagName), props))
+  insertedElements.push(element)
+  return element
+}
+
+export const resetElements = () => {
+  for (const element of insertedElements) element.remove()
+  insertedElements = []
+}
+
+/*
+ ! Since JSDOM does not support `window.matchMedia`, all of the following code
+ ! is trying to crudely polyfill it.
+ */
+
+/**
+ * Return which scheme the query string in the form of (prefers-color-scheme: scheme) is targeting.
+ * @param { string } media
+ */
+const getColorSchemeFromMedia = media => (/dark/.test(media) ? 'dark' : 'light')
+
+/**
+ * Keep track of the fake color scheme that is currently active.
+ *
+ * Allows subscribing and unsubscribing to changes, which is necessary for the
+ * `addListener` / `removeListener` capabilities of a MediaQuery.
+ */
+export const GlobalColorScheme = {
+  get current() {
+    return GlobalColorScheme._current
+  },
+  set current(colorScheme) {
+    // Update the global color scheme...
+    GlobalColorScheme._current = colorScheme
+    // And run all the listener that are listening for color scheme changes.
+    GlobalColorScheme.subscriptions.forEach(([listener, mediaQuery]) => {
+      // @ts-ignore
+      // Update MediaQueryList.matches of the MediaQuery associated with the Listener
+      mediaQuery.matches = getColorSchemeFromMedia(mediaQuery.media) === GlobalColorScheme.current
+      // Then run the Listener
+      listener.call(mediaQuery, Object.assign(new Event('change'), mediaQuery))
+    })
+  },
+  reset() {
+    GlobalColorScheme.subscriptions = []
+    GlobalColorScheme.current = null
+  },
+  /**
+   * @param { QueryListener } callback
+   * @param { MediaQueryList } mediaQuery
+   */
+  subscribe(callback, mediaQuery) {
+    if (callback) GlobalColorScheme.subscriptions.push([callback, mediaQuery])
+  },
+  /** @param { QueryListener } callback */
+  unsubscribe(callback) {
+    if (!callback) return
+    const index = GlobalColorScheme.subscriptions.findIndex(([listener]) => listener === callback)
+    GlobalColorScheme.subscriptions.splice(index, 1)
+  },
+  /** @type { [NonNullable<QueryListener>, MediaQueryList][] } */ subscriptions: [],
+  /** @type { ?ColorScheme } @readonly */ _current: null,
+}
+
+/**
+ * Creates a new MediaQuery.
+ * @type { Window['matchMedia'] }
+ */
+export const matchMedia = media => {
+  /** @type { MediaQueryList } */
+  const mediaQuery = {
+    media,
+    matches: getColorSchemeFromMedia(media) === GlobalColorScheme.current,
+    addListener: listener => GlobalColorScheme.subscribe(listener, mediaQuery),
+    removeListener: listener => GlobalColorScheme.unsubscribe(listener),
+
+    // Not implemented
+    onchange: () => {},
+    dispatchEvent: () => false,
+    addEventListener() {},
+    removeEventListener() {},
+  }
+
+  return mediaQuery
+}


### PR DESCRIPTION
## [1.1.0] - 2019-06-11

### Added

- You can now pass selector strings or `<link>` elements directly, rather than wrapping it in a config object.
- When using an Array to specify multiple icons to target, the different options (selector, `HTMLLinkElement`, config object) can be mixed-and-matched
- In addition to Arrays, `favicon-mode-switcher` now also supports `NodeList` so you can use it with `document.querySelectorAll()`